### PR TITLE
Add centos ci template

### DIFF
--- a/tests/.cico-run-tests.sh
+++ b/tests/.cico-run-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install dependencies
+yum -y install @development make
+
+# Run Tests
+./bootstrap; ./configure --disable-all --enable-cmake; make check

--- a/tests/.cico.yaml
+++ b/tests/.cico.yaml
@@ -84,7 +84,7 @@
             exit $rtn_codek
 
 - project:
-    name: <name_of_your_project_in_cico>
+    name: sig-hpc
     jobs:
         - '{ci_project}-{git_repo}':
             git_username: adrianreber

--- a/tests/.cico.yaml
+++ b/tests/.cico.yaml
@@ -1,0 +1,94 @@
+- trigger:
+    name: githubprb
+    triggers:
+      - github-pull-request:
+          admin-list:
+              - adrianreber
+          cron: '* * * * *'
+          github-hooks: true
+          permit-all: false
+          trigger-phrase: '.*test.*'
+          allow-whitelist-orgs-as-admins: true
+
+- scm:
+    name: git-scm
+    scm:
+        - git:
+            url: "{git_url}"
+            skip-tag: True
+            git-tool: ci-git
+            refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+            branches:
+                - '${{ghprbActualCommit}}'
+
+- job-template:
+    name: '{ci_project}-{git_repo}'
+    description: |
+        Managed by Jenkins Job Builder, do not edit manually!
+    node: "{ci_project}"
+    properties:
+        - github:
+            url: https://github.com/{git_username}/{git_repo}/
+    scm:
+        - git-scm:
+            git_url: https://github.com/{git_username}/{git_repo}.git
+    triggers:
+        - githubprb
+    builders:
+        - shell: |
+            set +e
+            export CICO_API_KEY=$(cat ~/duffy.key )
+            # get node
+            n=1
+            while true
+            do
+                cico_output=$(cico node get -f value -c ip_address -c comment)
+                if [ $? -eq 0 ]; then
+                    read CICO_hostname CICO_ssid <<< $cico_output
+                    if  [ ! -z "$CICO_hostname" ]; then
+                        # we got hostname from cico
+                        break
+                    fi
+                    echo "'cico node get' succeed, but can't get hostname from output"
+                fi
+                if [ $n -gt 5 ]; then
+                    # give up after 5 tries
+                    echo "giving up on 'cico node get'"
+                    exit 1
+                fi
+                echo "'cico node get' failed, trying again in 60s ($n/5)"
+                n=$[$n+1]
+                sleep 60
+            done
+            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+            ssh_cmd="ssh $sshopts $CICO_hostname"
+            # Save the jenkins environment if needed
+            env > jenkins-env
+            $ssh_cmd yum -y install rsync
+            # Checkout the pull request that we received from the githubPRB plugin
+            git rebase --preserve-merges origin/${{ghprbTargetBranch}} \
+            && rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
+            && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
+            rtn_code=$?
+            if [ $rtn_code -eq 0 ]; then
+                cico node done $CICO_ssid
+            else
+                if [[ $rtn_code -eq 124 ]]; then
+                   echo "BUILD TIMEOUT";
+                   cico node done $CICO_ssid
+                else
+                    # fail mode gives us 12 hrs to debug the machine
+                    curl "http://admin.ci.centos.org:8080/Node/fail?key=$CICO_API_KEY&ssid=$CICO_ssid"
+                fi
+            fi
+            exit $rtn_codek
+
+- project:
+    name: <name_of_your_project_in_cico>
+    jobs:
+        - '{ci_project}-{git_repo}':
+            git_username: adrianreber
+            git_repo: ohpc
+            ci_project: '{name}'
+            ci_cmd: "cd tests && .cico-run-tests.sh"
+            timeout: '120m'


### PR DESCRIPTION
This adds a job to CentOS CI for testing each pull request, once this is merged it will show up here: 

https://ci.centos.org/job/sig-hpc-ohpc/

You can modify `tests/.cico-run-tests.sh` which is the script that gets run on the provisioned machine. You start with a minimal install, so you may need to add packages to the dependency line. 

Commenting 'test' on an open PR will cause the job to get retriggered. Changes to the jobs should be done on the obs/OpenHPC_1.3.1_Factory branch, if we should monitor a different branch please let us know.